### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/game/direction.go
+++ b/game/direction.go
@@ -38,7 +38,7 @@ type Direction struct {
 	Aliases []string
 }
 
-// FindDir will find a direction by name or alias.  This method is not case
+// FindDirection will find a direction by name or alias.  This method is not case
 // sensitive.
 func FindDirection(alias string) (dir Direction, found bool) {
 	dir, found = dirMap[strings.ToLower(alias)]

--- a/magefile.go
+++ b/magefile.go
@@ -56,7 +56,7 @@ func Release() (err error) {
 	return sh.RunV("goreleaser")
 }
 
-// Remove the temporarily generated files from Release.
+// Clean removes the temporarily generated files from Release.
 func Clean() error {
 	return sh.Rm("dist")
 }

--- a/world/location.go
+++ b/world/location.go
@@ -48,7 +48,7 @@ type Location struct {
 	Actions map[string]Action
 }
 
-// returns a string representation of this location (primarily for logging)
+// String returns a string representation of this location (primarily for logging)
 func (l *Location) String() string {
 	return fmt.Sprintf("%v [%v]", l.Name, l.ID)
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?